### PR TITLE
Setup nginx proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ ENCRYPTION_MNEMONIC=
 
 ## Domain to use for your archaeologist
 ## This domain should be pointed with an A record to your server's IP
-DOMAIN=
+DOMAIN=my.exampledomain.com
 
 ## RPC provider. Recommend updating this to use your own provider (infura, alchemy, etc).
 PROVIDER_URL=https://rpc.ankr.com/eth_goerli

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 ## Setup Instructions
 
 ### Prerequisites:
-- Running a [server with the following installed](https://marketplace.digitalocean.com/apps/docker):
+- Running a server with the following installed:
   - git
   - [docker (>= 20.0)](https://www.simplilearn.com/tutorials/docker-tutorial/how-to-install-docker-on-ubuntu)
   - [docker compose (>= 2.0.0)](https://docs.docker.com/compose/install/linux/#install-the-plugin-manually)
+  - An example of a server with these prerequisites already installed: [https://marketplace.digitalocean.com/apps/docker](https://marketplace.digitalocean.com/apps/docker)
 - ETH wallet (private key) with:
   - ETH balance (for signing transactions)
   - SARCO balance (for bonding your archaeologist to curses)
+- BIP39 compatible mnemonic (generate a new one here: [https://iancoleman.io/bip39/](https://iancoleman.io/bip39/))
 - RPC URL (Infura, Alchemy, etc.)
 
-_If running on Goerli (chain id = 5), then you will need Goerli ETH + Goerli SARCO._
+_If running on Goerli (chain id = 5) or Sepolia (chain id = 11155111), then you will need Goerli/Sepolia ETH + Goerli/Sepolia SARCO._
 
+- A registered domain name [pointed at your server's ip address](https://www.servers.com/support/knowledge/dedicated-servers/how-to-point-your-domain-name-to-dedicated-servers-ip-address#:~:text=To%20point%20your%20domain%20name%20to%20your%20dedicated%20server's%20public,on%20the%20domain's%20name%20servers.) 
 ---
 
 ### Initial Setup Instructions
@@ -20,8 +23,7 @@ _If running on Goerli (chain id = 5), then you will need Goerli ETH + Goerli SAR
 
    `git clone https://github.com/sarcophagus-org/quickstart-archaeologist`
 
-
-2. Copy example env file, and fill out the env file values.
+2. Copy example env file, and fill out the env file values. See example env for explanation
 
    `cp .env.example .env`
 
@@ -30,17 +32,16 @@ _If running on Goerli (chain id = 5), then you will need Goerli ETH + Goerli SAR
    `touch peer-id.json`
 
 4. **If you have not yet registered your archaeologist:**
-   > `COMPOSE_PROFILES=register docker compose run -rm register`  
+
+   > `COMPOSE_PROFILES=register docker compose run register`  
    
-_(or `docker-compose` for older versions of docker compose)_
+   _(or `docker-compose` for older versions of docker compose)_
+
+   Follow the instructions to register your archaeologist. A peer ID will automatically be generated for you.
 
 5. Run the service
-   >  `COMPOSE_PROFILES=service docker compose up`
 
-### Registering your archaeologist
-If this is your first time running the service, you will be prompted to register your archaeologist.
-
-Follow the prompts to register your archaeologist.
+   > `COMPOSE_PROFILES=service docker compose up`
 
 ### CLI
 To run the CLI: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,9 @@ services:
       FORCE_COLOR: 1
       NODE_NO_WARNINGS: 1
       CHAIN_ID: 11155111
-      VIRTUAL_HOST: 
+      VIRTUAL_HOST: ${DOMAIN}
       VIRTUAL_PORT: 9000
-      LETSENCRYPT_HOST: 
+      LETSENCRYPT_HOST: ${DOMAIN}
     expose:
       - "9000"
     depends_on:
@@ -83,7 +83,6 @@ services:
       - acme:/etc/acme.sh
     environment:
       NGINX_PROXY_CONTAINER: "nginx-proxy"
-      DEFAULT_EMAIL: ""
     depends_on:
       - nginx-proxy
 


### PR DESCRIPTION
Update docker compose to use nginx proxy + acme companion, used for automatically proxying requests from the outside world to the service. 

acme companion is used to automatically register + renew letsencrypt SSL certs so that operator doesnt have to manually run certbot.